### PR TITLE
エンドポイントへのアクセス時にAuthorizationヘッダのトークン検証を実施する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # cohabi-api
 
 ## 実行方法
-- /ディレクトにあるapp.pyを実行する
-  - 引数に環境名であるdev(開発)/stg(ステージング)/prd(本番)を指定する。
+
+- /ディレクトにある app.py を実行する
+  - 引数に環境名である dev(開発)/stg(ステージング)/prd(本番)を指定する。
 
 ## setting info
 
@@ -11,11 +12,18 @@
   - https://fastapi.tiangolo.com/ja/
 
 - この repository を動作させる上で行った設定や cmd 郡
+
   - ./setting_info/を確認
 
-- FastAPIのdockerについて
+- FastAPI の docker について
   - https://fastapi.tiangolo.com/ja/deployment/docker/
   - https://qiita.com/FN_Programming/items/2dcabc93365a62397afe
+
+## 認証
+
+- 開発時、一時的に認証機構をオフにする場合は、app.auth.authorizer.py の`DISABLE_AUTH`を`True`にしてください
+  - 戻り値の AuthResult.user が`testuser01`になります。
+- git へのプッシュ時は必ず`False`に戻してください。
 
 ## codeing 方法
 
@@ -36,10 +44,11 @@
 
   - https://qiita.com/hoto17296/items/fb1b7304128f4c90af69
 
-  - cursorを使うことで複数のトランザクションを扱うことができるらしい！
+  - cursor を使うことで複数のトランザクションを扱うことができるらしい！
+
     - https://qiita.com/ta_ta_ta_miya/items/b95c7a2e5e32545c8adc
 
-  - tryとfinallyを使って必ずcursorを閉じるようにするのが望ましい！！
+  - try と finally を使って必ず cursor を閉じるようにするのが望ましい！！
     - https://qiita.com/umezawatakeshi/items/6c3483ea0e082f2d8926
 
 - mysqlclinet の conect について
@@ -116,7 +125,9 @@
     - https://nmomos.com/tips/2021/01/23/fastapi-docker-1/
 
 ## その他
-- gitignorについて(一応)
+
+- gitignor について(一応)
+
   - https://qiita.com/inabe49/items/16ee3d9d1ce68daa9fff
 
 - docker 環境について

--- a/app/auth/authorizer.py
+++ b/app/auth/authorizer.py
@@ -1,0 +1,91 @@
+import json
+from jose import jwt
+from urllib.request import urlopen
+from starlette.requests import Request
+
+from app.util import logger
+
+# FIXME: 開発時以外は必ずTrueにすること
+DISABLE_AUTH = False
+AUTH0_DOMAIN = 'dev-uql6wxih.jp.auth0.com'
+API_AUDIENCE = 'https://api-staging.cohabi.runemosuky.com'
+ALGORITHMS = ["RS256"]
+
+
+class AuthResult:
+    def __init__(self, error_code: str = "", error_detail: str = "", usersub: str = None) -> None:
+        self.error_code = error_code
+        self.error_detail = error_detail
+        self.user = usersub
+
+    def to_json(self):
+        return json.dumps(self.__dict__, ensure_ascii=False, indent=4)
+
+
+def create_auth_error(code: str = "", detail: str = ""):
+    logger.error(
+        "AUTH ERROR [CODE]: {0} [DETAIL]: {1}".format(code, detail))
+    return AuthResult(error_code=code, error_detail=detail)
+
+
+def get_jwk_from_auth0API():
+    # Auth0APIからJWK(公開鍵)を取得
+    jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
+    jwks = json.loads(jsonurl.read())
+    return jwks
+
+
+def authorized_user(request: Request) -> AuthResult:
+    if DISABLE_AUTH:
+        return AuthResult(usersub="testuser01")
+
+    """Obtains the Access Token from the Authorization Header
+    """
+    auth = request.headers.get("Authorization", None)
+    if not auth:
+        return create_auth_error(code="authorization_header_missing", detail="Authorization header is expected")
+    parts = auth.split()
+    if parts[0].lower() != "bearer":
+        return create_auth_error(code="invalid_header", detail="Authorization header must start with Bearer")
+    elif len(parts) == 1:
+        return create_auth_error(code="invalid_header", detail="Token not found")
+    elif len(parts) > 2:
+        return create_auth_error(code="invalid_header", detail="Authorization header must be Bearer token")
+    token = parts[1]
+
+    """Get Public Key from Auth0
+    """
+    jwks = get_jwk_from_auth0API()
+
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except Exception:
+        return create_auth_error(code="unable_decode_token", detail="Token must include unverified header")
+
+    rsa_key = {}
+    for key in jwks["keys"]:
+        if key["kid"] == unverified_header["kid"]:
+            rsa_key = {
+                "kty": key["kty"],
+                "kid": key["kid"],
+                "use": key["use"],
+                "n": key["n"],
+                "e": key["e"]
+            }
+    if rsa_key:
+        try:
+            payload = jwt.decode(
+                token,
+                rsa_key,
+                algorithms=ALGORITHMS,
+                audience=API_AUDIENCE,
+                issuer="https://"+AUTH0_DOMAIN+"/"
+            )
+        except jwt.ExpiredSignatureError:
+            return create_auth_error(code="token_expired", detail="token is expired")
+        except jwt.JWTClaimsError:
+            return create_auth_error(code="invalid_claims", detail="incorrect claims, please check the audience and issuer")
+        except Exception:
+            return create_auth_error(code="invalid_header", detail="Unable to parse authentication, token.")
+        return AuthResult(usersub=payload['sub'])
+    return create_auth_error(code="invalid_header", detail="Unable to find appropriate key")

--- a/app/main.py
+++ b/app/main.py
@@ -13,17 +13,18 @@ app = FastAPI()
 
 # originに接続元を許可するURLを記載
 origins = [
-    "https://cohabi.runemosuky.com"
+    "https://cohabi-staging.runemosuky.com"
 ]
 
 # 接続の許可設定
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins, # originsから来たやつを許可している
+    allow_origins=origins,  # originsから来たやつを許可している
     allow_credentials=True,
-    allow_methods=["*"], # リクエストのメソッドは何でも良い
+    allow_methods=["*"],  # リクエストのメソッドは何でも良い
     allow_headers=["*"],
 )
+
 
 # uvicornから起動した際実行
 @app.on_event("startup")
@@ -34,7 +35,7 @@ async def startup():
 
     # dbとのconnectionを作成
     db_session.start_conn('./key/secret.json')
-    
+
 
 # uvicornを終了した際に実行
 @app.on_event("shutdown")

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ app = FastAPI()
 
 # originに接続元を許可するURLを記載
 origins = [
+    # TODO: 環境変数から取るようにしたい。環境ごとに許可する対象が代わり共存したくないため。
     "https://cohabi-staging.runemosuky.com"
 ]
 

--- a/app/model/api_result.py
+++ b/app/model/api_result.py
@@ -1,0 +1,20 @@
+import json
+from typing import List
+
+
+class ApiError:
+    def __init__(self, error_code: str = "", error_messages: List[str] = []) -> None:
+        self.error_code = error_code
+        self.error_messages = error_messages
+
+
+class ApiResult:
+    def __init__(self, result: ApiError = ApiError(error_code="", error_messages=[]), body: dict = None):
+        self.result = {
+            'error_code': result.error_code,
+            'error_messages': result.error_messages
+        }
+        self.body = body
+
+    def to_json(self):
+        return json.dumps(self.__dict__, ensure_ascii=False, indent=4)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,48 +1,51 @@
 # installライブラリー
-from app.util import logger
 from fastapi import APIRouter
-from app.service import helloworld as helloworld_service
+from fastapi.params import Depends
 from pydantic import BaseModel
+
+from app.auth.authorizer import authorized_user, AuthResult
+from app.service import helloworld as helloworld_service
+from app.model.api_result import ApiError, ApiResult
+from app.util import logger
 
 router = APIRouter()
 
-# returnする際のクラスを作成
-class ReturnType:
-    def __init__(self, body:dict):
-        self.result = {
-            "error_code": "",
-            "error_messages": []
-        }
-
-        self.body = body
-
 
 @router.get("/helloworld")
-async def get_helloworld():
+async def get_helloworld(auth: AuthResult = Depends(authorized_user)):
+    # TODO: 毎回これを書くのが面倒なのでAuth Filter的な実装にしたい
+    if auth.user == None:
+        return ApiResult(result=ApiError(error_code=auth.error_code, error_messages=[auth.error_detail]))
+
     user_names = helloworld_service.get()
-    
+
     body = {
         'users': user_names
     }
 
-    return_type = ReturnType(body)
+    result = ApiResult(body=body)
 
-    logger.debug(return_type)
-    return return_type
+    logger.debug(result.to_json())
+    return result
+
 
 # input情報の入力値を決定する
 class postUser(BaseModel):
     name: str
 
+
 @router.post("/helloworld")
-async def create_helloworld(body: postUser):
+async def create_helloworld(body: postUser, auth: AuthResult = Depends(authorized_user)):
+    if auth.user == None:
+        return ApiResult(result=ApiError(error_code=auth.error_code, error_messages=[auth.error_detail]))
+
     helloworld_service.create(body.name)
 
     # TODO: クリエイトしたユーザーを返す
     body = {
         'users': ""
     }
-    result = ReturnType(body)
+    result = ApiResult(body=body)
 
-    logger.debug(result)
+    logger.debug(result.to_json())
     return result

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.65.2
 uvicorn==0.14.0
+mysqlclient==2.0.3
+python-jose==3.3.0

--- a/setting_info/dev-env_setting_info.md
+++ b/setting_info/dev-env_setting_info.md
@@ -1,4 +1,5 @@
-# cohabi-appの開発環境作成について
+# cohabi-app の開発環境作成について
+
 ```sh
 アナコンダを使用した場合のpython環境の作成
 # conda create -n cohabi-api python=3.8
@@ -15,5 +16,7 @@ ASGI用のモジュール
 mySQLのクライアントモジュール
 # pip install mysqlclient
 
+jwtモジュール
+# pip install python-jose
 
 ```


### PR DESCRIPTION
close #7 

# やったこと

## 認証

- Authorizationヘッダを検証する関数を作成
- 各ルートで上記関数を実行するようにしました

## リファクタ

- Apiが返す型をmodelに移動しました
- 僕のvscodeだと保存するだけでフォーマットがかかってしまうので、不要な変更が入ってしまっているかも

# 追加モジュール
- python-joseモジュールが多分必要です
  - `pip install python-jose`