### PR TITLE
dockerfileの動くサンプルを作成

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,17 +1,26 @@
+### Command
+# $ cd path/to/cohabi-api
+# $ docker build -t python-backend:latest -f docker/dockerfile .
+# $ docker run -it -p 8000:8000 python-backend:latest
+
 FROM python:3.9-alpine
 
-WORKDIR /backend
+WORKDIR /app
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONBUFFERED 1
-
-COPY ./requirements.txt /backend/requirements.txt
+COPY docker/requirements.txt docker/requirements.txt
 
 RUN set -eux \
- && apk add --no-cache build-base \
- && pip install --upgrade pip setuptools wheel \
- && pip install --no-cache-dir --trusted-host pypi.python.org -r /backend/requirements.txt \
- && apk del build-base \
- && rm -rf /root/.cache/pip
+    && apk update \
+    && apk add --no-cache \
+    build-base \
+    gcc \
+    mariadb-dev \
+    && pip install --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir --trusted-host pypi.python.org -r docker/requirements.txt \
+    && apk del build-base
 
-COPY .. /backend
+COPY . .
+
+EXPOSE 8000
+# FastAPIを8000ポートで待機
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.65.2
 uvicorn==0.14.0
+mysqlclient==2.0.3
+python-jose==3.3.0


### PR DESCRIPTION
書いてあるコマンドを流せば動きますたぶん
書いてあるとおり`cohabi-api`ディレクトリで実行してください
HotReloadとかは対応してません、標準入出力にバインドされる、とりあえず動くだけ
コマンド実行後`http://localhost:8000/helloworld`にアクセスすれば動く

- mysqlclientを動かすには、`gcc`と`mariadb-dev`が必要らしいです。
  - https://zenn.dev/wtkn25/articles/python-docker-mysqlclient
  - https://qiita.com/satto_sann/items/4fbc1a4e2b33fa2237d2
- 認証を追加するために、requirementsにpython-joseを追加する必要があるみたいなので、一応入ってます
- 最終的にどうなったら良いかがわからなかったのでドラフトにしてます(マージしない)