### PR TITLE
マイグレーションツールを導入

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,89 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = db
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to db/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat db/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/db/README
+++ b/db/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/db/env.py
+++ b/db/env.py
@@ -1,0 +1,80 @@
+from logging.config import fileConfig
+from MySQLdb import STRING
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+from db.util import get_db_dsn
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+config.set_main_option('sqlalchemy.url', get_db_dsn('./key/secret.json'))
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/db/script.py.mako
+++ b/db/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/db/util.py
+++ b/db/util.py
@@ -1,0 +1,15 @@
+import json
+
+
+def get_db_dsn(path: str) -> str:
+    with open(path) as f:
+        acskey = json.load(f)
+
+    db_acs = acskey['database']
+
+    return 'mysql://{user}:{passwd}@{host}/{dbname}'.format(
+        user=db_acs["user"],
+        passwd=db_acs["passwd"],
+        host=db_acs["host"],
+        dbname=db_acs["db"],
+    )

--- a/db/versions/1fbc85ca7268_create_membership_table.py
+++ b/db/versions/1fbc85ca7268_create_membership_table.py
@@ -1,0 +1,38 @@
+"""create membership table
+
+Revision ID: 1fbc85ca7268
+Revises: e93ade9606b4
+Create Date: 2021-07-12 02:51:35.104765
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1fbc85ca7268'
+down_revision = 'e93ade9606b4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'membership',
+        sa.Column(
+            'group_id',
+            sa.String(36),
+            sa.ForeignKey('group.id'),
+            primary_key=True
+        ),
+        sa.Column(
+            'user_id',
+            sa.String(255),
+            sa.ForeignKey('user.id'),
+            primary_key=True
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table('membership')

--- a/db/versions/568731159647_create_user_table.py
+++ b/db/versions/568731159647_create_user_table.py
@@ -21,7 +21,7 @@ def upgrade():
         'user',
         sa.Column('id', sa.String(36), primary_key=True),
         sa.Column('name', sa.String(255), nullable=False),
-        sa.Column('idp-id', sa.String(255), nullable=False),
+        sa.Column('idp_id', sa.String(255), nullable=False),
         sa.Column('email', sa.String(255), nullable=False),
         sa.Column('icon', sa.String(255)),
     )

--- a/db/versions/568731159647_create_user_table.py
+++ b/db/versions/568731159647_create_user_table.py
@@ -1,0 +1,31 @@
+"""create user table
+
+Revision ID: 568731159647
+Revises: 
+Create Date: 2021-07-12 02:14:28.555245
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '568731159647'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('idp-id', sa.String(255), nullable=False),
+        sa.Column('email', sa.String(255), nullable=False),
+        sa.Column('icon', sa.String(255)),
+    )
+
+
+def downgrade():
+    op.drop_table('user')

--- a/db/versions/e93ade9606b4_create_group_table.py
+++ b/db/versions/e93ade9606b4_create_group_table.py
@@ -1,0 +1,28 @@
+"""create group table
+
+Revision ID: e93ade9606b4
+Revises: 568731159647
+Create Date: 2021-07-12 02:48:56.968049
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e93ade9606b4'
+down_revision = '568731159647'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'group',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(255), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('group')

--- a/db/versions/f9f552da2c9b_create_category_table.py
+++ b/db/versions/f9f552da2c9b_create_category_table.py
@@ -1,0 +1,41 @@
+"""create category table
+
+Revision ID: f9f552da2c9b
+Revises: 1fbc85ca7268
+Create Date: 2021-07-12 02:57:10.558528
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f9f552da2c9b'
+down_revision = '1fbc85ca7268'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'category',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column(
+            'group_id',
+            sa.String(36),
+            sa.ForeignKey('group.id'),
+            nullable=False
+        ),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('index', sa.SMALLINT(), nullable=False),
+        sa.Column(
+            'disabled',
+            sa.BOOLEAN,
+            server_default="0",
+            nullable=False
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table('category')

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.65.2
 uvicorn==0.14.0
+alembic==1.6.5

--- a/key/secret.local.json
+++ b/key/secret.local.json
@@ -1,0 +1,8 @@
+{
+    "database": {
+        "user": "admin",
+        "passwd": "admin",
+        "host": "localhost",
+        "db": "cohabi_development"
+    }
+}

--- a/setting_info/db.md
+++ b/setting_info/db.md
@@ -40,4 +40,10 @@ cohabi-api > alembic revision -m "some operation name"
 - 作成されたファイルに加える変更内容をスクラッチで書いて、マイグレーションの実行を行う
   - sqlalchemy と連携することで auto generate できるらしいけど、ORM 使わないので無視
 - 基本的に一度マイグレーション投げたら変更しない
+
   - 変更する場合は、一度ダウングレードしてからファイルを変更し、再度マイグレーションを行う
+
+    ```shell
+    # 一個前の状態に戻す
+    cohabi-api > alembic downgrade -1
+    ```

--- a/setting_info/db.md
+++ b/setting_info/db.md
@@ -28,6 +28,8 @@ $ > pip install alembic
 cohabi-api > alembic upgrade head
 ```
 
+- db に`alembic_version`というメタテーブルができます
+
 ### DB に変更を加える場合
 
 ```shell

--- a/setting_info/db.md
+++ b/setting_info/db.md
@@ -1,0 +1,41 @@
+# DB の設定
+
+## DB のマイグレーション
+
+### とは
+
+- 開発中に DB のテーブル定義が変わった時のバージョニングをしたい
+- 人間が管理するのは大変なので、ツールを使う
+- python で有名なツール[alembic](https://github.com/sqlalchemy/alembic)を使用
+  - sqlalchemy という ORM と互換性が良いらしいが、使っていないので無視
+  - マイグレーションする機能だけ使用する
+
+### インストール
+
+```shell
+$ > pip install alembic
+```
+
+### 設定
+
+- 接続設定は、`key/secret.json`を使用します。**間違って本番環境に migration 投げないように注意**。なんかいい方法ないかな...
+- 一応、`db/env.py`の中で接続設定ファイルの場所を指定しているので、そこを変えれば本番とファイル名共用しなくて済みはする。
+
+### マイグレーションの実行
+
+```shell
+# secret.json の内容を確認してから
+cohabi-api > alembic upgrade head
+```
+
+### DB に変更を加える場合
+
+```shell
+cohabi-api > alembic revision -m "some operation name"
+# db/versions/xxxxxxxxxxxx_some_operation_name.pyが作成される
+```
+
+- 作成されたファイルに加える変更内容をスクラッチで書いて、マイグレーションの実行を行う
+  - sqlalchemy と連携することで auto generate できるらしいけど、ORM 使わないので無視
+- 基本的に一度マイグレーション投げたら変更しない
+  - 変更する場合は、一度ダウングレードしてからファイルを変更し、再度マイグレーションを行う


### PR DESCRIPTION
# 対応issue
#13 

# やったこと
## マイグレーションツールを導入
- alembicというツールを導入した
- 接続情報をpythonから渡せるというのが主な理由

## テーブル定義を作成
- user
- group
- category
を導入してみた

- テーブル名は一旦単数系